### PR TITLE
Allow to configure the font encoding via parameter font_encoding

### DIFF
--- a/lib/PDF/ReportWriter.pm
+++ b/lib/PDF/ReportWriter.pm
@@ -4057,6 +4057,14 @@ When you include a font 'family', a range of fonts ( roman, italic, bold, etc ) 
 
 =back
 
+=head2 font_encoding
+
+=over 4
+
+The font encoding used which defaults to 'latin1' but can be changed ot e.g. to 'utf8'.
+
+=back
+
 =head2 default_font
 
 =over 4

--- a/lib/PDF/ReportWriter.pm
+++ b/lib/PDF/ReportWriter.pm
@@ -294,25 +294,28 @@ sub parse_options
     # Add requested fonts
     $opt->{font_list} ||= $opt->{font} || [ 'Helvetica' ];
     
+    # Requested encoding or default latin1
+    $opt->{font_encoding} ||= 'latin1';
+    
     for my $font ( @{$opt->{font_list}} ) {
         
         # Roman fonts are easy
-        $self->{fonts}->{$font}->{Roman} = $self->{pdf}->corefont(          $font,                  -encoding => 'latin1');
+        $self->{fonts}->{$font}->{Roman} = $self->{pdf}->corefont(          $font,                  -encoding => $opt->{font_encoding});
         # The rest are f'n ridiculous. Adobe either didn't think about this, or are just stoopid
         if ($font eq 'Courier') {
-            $self->{fonts}->{$font}->{Bold} = $self->{pdf}->corefont(       "Courier-Bold",         -encoding => 'latin1');
-            $self->{fonts}->{$font}->{Italic} = $self->{pdf}->corefont(     "Courier-Oblique",      -encoding => 'latin1');
-            $self->{fonts}->{$font}->{BoldItalic} = $self->{pdf}->corefont( "Courier-BoldOblique",  -encoding => 'latin1');
+            $self->{fonts}->{$font}->{Bold} = $self->{pdf}->corefont(       "Courier-Bold",         -encoding => $opt->{font_encoding});
+            $self->{fonts}->{$font}->{Italic} = $self->{pdf}->corefont(     "Courier-Oblique",      -encoding => $opt->{font_encoding});
+            $self->{fonts}->{$font}->{BoldItalic} = $self->{pdf}->corefont( "Courier-BoldOblique",  -encoding => $opt->{font_encoding});
         }
         if ($font eq 'Helvetica') {
-            $self->{fonts}->{$font}->{Bold} = $self->{pdf}->corefont(       "Helvetica-Bold",       -encoding => 'latin1');
-            $self->{fonts}->{$font}->{Italic} = $self->{pdf}->corefont(     "Helvetica-Oblique",    -encoding => 'latin1');
-            $self->{fonts}->{$font}->{BoldItalic} = $self->{pdf}->corefont( "Helvetica-BoldOblique",-encoding => 'latin1');
+            $self->{fonts}->{$font}->{Bold} = $self->{pdf}->corefont(       "Helvetica-Bold",       -encoding => $opt->{font_encoding});
+            $self->{fonts}->{$font}->{Italic} = $self->{pdf}->corefont(     "Helvetica-Oblique",    -encoding => $opt->{font_encoding});
+            $self->{fonts}->{$font}->{BoldItalic} = $self->{pdf}->corefont( "Helvetica-BoldOblique",-encoding => $opt->{font_encoding});
         }
         if ($font eq 'Times') {
-            $self->{fonts}->{$font}->{Bold} = $self->{pdf}->corefont(       "Times-Bold",           -encoding => 'latin1');
-            $self->{fonts}->{$font}->{Italic} = $self->{pdf}->corefont(     "Times-Italic",         -encoding => 'latin1');
-            $self->{fonts}->{$font}->{BoldItalic} = $self->{pdf}->corefont( "Times-BoldItalic",     -encoding => 'latin1');
+            $self->{fonts}->{$font}->{Bold} = $self->{pdf}->corefont(       "Times-Bold",           -encoding => $opt->{font_encoding});
+            $self->{fonts}->{$font}->{Italic} = $self->{pdf}->corefont(     "Times-Italic",         -encoding => $opt->{font_encoding});
+            $self->{fonts}->{$font}->{BoldItalic} = $self->{pdf}->corefont( "Times-BoldItalic",     -encoding => $opt->{font_encoding});
         }
     }
     


### PR DESCRIPTION
This PR allows to configure the font encoding which is used when initializing the PDF::API2 fonts e.g. to set it from default `latin1` to  `utf8`.